### PR TITLE
Improve parallel processing; PatientSurvivalGraph

### DIFF
--- a/fhir_query/__init__.py
+++ b/fhir_query/__init__.py
@@ -435,7 +435,6 @@ class GraphDefinitionRunner(ResourceDB):
                 if link["sourceId"] in parent_resource_types:
                     processed_links.append(link)
                     parallelize[link["sourceId"]].append(link)
-                    print(link)
 
             if not parallelize:
                 break

--- a/fhir_query/cli.py
+++ b/fhir_query/cli.py
@@ -80,7 +80,6 @@ def main(
 
         logging.debug(runner.db_path)
         spinner = Halo(text=f"Running {_.id} traversal", spinner="dots", stream=sys.stderr)
-        spinner.start()
         try:
             await runner.run(graph_definition, path, spinner)
         finally:

--- a/fhir_query/cli.py
+++ b/fhir_query/cli.py
@@ -2,19 +2,17 @@ import asyncio
 import json
 import logging
 import sys
-from collections import defaultdict
 from typing import Any
 
-import pandas as pd
-
 import click
+import pandas as pd
 import requests
-from click_default_group import DefaultGroup
 import yaml
+from click_default_group import DefaultGroup
 from fhir.resources.graphdefinition import GraphDefinition
 from halo import Halo
 
-from fhir_query import GraphDefinitionRunner, setup_logging, VocabularyRunner
+from fhir_query import GraphDefinitionRunner, setup_logging
 from fhir_query.dataframer import Dataframer
 from fhir_query.visualizer import visualize_aggregation
 from fhir_query.vocabulary import vocabulary_simplifier

--- a/fhir_query/dataframer.py
+++ b/fhir_query/dataframer.py
@@ -180,7 +180,7 @@ def traverse(resource):
 
 
 class SimplifiedFHIR(BaseModel):
-    """All simplifiers should inherit from this class."""
+    """All Simplifiers should inherit from this class."""
 
     warnings: list[str] = []
     """A list of warnings generated during the simplification process."""
@@ -287,7 +287,7 @@ class SimplifiedFHIR(BaseModel):
     @property
     def values(self) -> dict:
         """Return a dictionary of source:value."""
-        # FIXME: values that are scalars are processed twice: once in scalars once here in values (eg valueString)
+        # FIXME: values that are scalars are processed twice: once in scalars once here in values (e.g. valueString)
         value, source = normalize_value(self.resource)
         if not value:
             return {}
@@ -402,9 +402,9 @@ class SimplifiedCondition(SimplifiedFHIR):
 
         # get field name
         codings_dict = super().codings
-        if "category" in codings_dict:
-            key = codings_dict["category"]
-            del codings_dict["category"]
+        if "cate.g.ory" in codings_dict:
+            key = codings_dict["cate.g.ory"]
+            del codings_dict["cate.g.ory"]
         else:
             key = "code"
 
@@ -452,7 +452,7 @@ class Dataframer(ResourceDB):
         return traverse(subject)
 
     def get_resources_by_reference(self, resource_type: str, reference_field: str, reference_type: str) -> dict[str, list]:
-        """given a set of rescode resources of type resource_type, map each unique reference in reference field of type reference_type to its associated resources
+        """Given a set of resources of type resource_type, map each unique reference in reference field of type reference_type to its associated resources
         ex: use all Observations with a Specimen focus, map Specimen IDs to its list of associated Observations and return the map
         """
 
@@ -477,15 +477,15 @@ class Dataframer(ResourceDB):
 
             # determine which how to process the field
             if reference_field == "focus" and "focus" in resource:
-                # add the resource (eg observation) for each focus reference to the dict
+                # add the resource (e.g. observation) for each focus reference to the dict
                 for i in range(len(resource["focus"])):
-                    reference_key = get_nested_value(resource, [reference_field, i, "reference"])
+                    reference_key: str = get_nested_value(resource, [reference_field, i, "reference"])
                     if reference_key is not None and reference_type in reference_key:
                         reference_id = reference_key.split("/")[-1]
                         resource_by_reference_id[reference_id].append(resource)
 
             if reference_field == "specimen" and "specimen" in resource:
-                # add the resource (eg observation) for each specimen reference to the dict
+                # add the resource (e.g. observation) for each specimen reference to the dict
                 for i in range(len(resource["specimen"])):
                     reference_key = get_nested_value(resource, [reference_field, i, "reference"])
                     if reference_key is not None and reference_type in reference_key:
@@ -493,7 +493,7 @@ class Dataframer(ResourceDB):
                         resource_by_reference_id[reference_id].append(resource)
 
             if reference_field == "basedOn" and "basedOn" in resource:
-                # add the resource (eg observation) for each basedOn reference to the dict
+                # add the resource (e.g. observation) for each basedOn reference to the dict
                 for i in range(len(resource["basedOn"])):
                     reference_key = get_nested_value(resource, [reference_field, i, "reference"])
                     if reference_key is not None and reference_type in reference_key:
@@ -501,7 +501,7 @@ class Dataframer(ResourceDB):
                         resource_by_reference_id[reference_id].append(resource)
 
             elif reference_field == "subject":
-                # add the resource (eg observation) to the dict
+                # add the resource (e.g. observation) to the dict
                 reference_key = get_nested_value(resource, [reference_field, "reference"])
                 if reference_key is not None and reference_type in reference_key:
                     reference_id = reference_key.split("/")[-1]
@@ -515,8 +515,8 @@ class Dataframer(ResourceDB):
 
     @lru_cache(maxsize=None)
     def flattened_specimens(self) -> Generator[dict, None, None]:
-        """generator that yields specimens populated with Specimen.subject fields
-        and Observation codes through Observation.focus"""
+        """generator that yields specimens populated with `Specimen.subject` fields
+        and Observation codes through `Observation.focus`"""
 
         resource_type = "Specimen"
         cursor = self.connection.cursor()

--- a/graph-definitions/R4/PatientSurvivalGraph.yaml
+++ b/graph-definitions/R4/PatientSurvivalGraph.yaml
@@ -1,0 +1,14 @@
+description: A graph to traverse Patient and Observations [NCIT_C156418,NCIT_C156419].
+id: patient-survival-graph
+name: PatientSurvivalGraph
+resourceType: GraphDefinition
+status: active
+link:
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: Patient
+- params: part-of-study={path}&code=NCIT_C156418,NCIT_C156419&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: Observation

--- a/graph-definitions/R4/ResearchStudyGraph.yaml
+++ b/graph-definitions/R4/ResearchStudyGraph.yaml
@@ -1,72 +1,59 @@
----
-resourceType: GraphDefinition
-id: research-study-graph
-name: ResearchStudyGraph
-status: active
 description: A graph to traverse ResearchStudy, ResearchSubject, Patient, Specimen,
   and DocumentReference.
-
+id: research-study-graph
+name: ResearchStudyGraph
+resourceType: GraphDefinition
+status: active
 link:
-- params: 'study={path}&_count=1000&_total=accurate'
+- params: part-of-study={path}&_count=1000&_total=accurate
   sourceId: ResearchStudy
   targetId: ResearchSubject
   path: ResearchStudy.id
-- sourceId: ResearchStudy
-  params: _has:ResearchSubject:subject:study={path}&_revinclude=Group:member&_revinclude=Condition:subject&_count=1000&_total=accurate
-  path: ResearchStudy.id
-  targetId: Patient
-- sourceId: Patient
-  params: subject={path}&_revinclude=Group:member&_count=1000&_total=accurate
-  path: Patient.id
-  targetId: Specimen
-- sourceId: Patient
-  params: subject={path}&_count=1000&_total=accurate
-  path: Patient.id
-  targetId: ImagingStudy
-- sourceId: Patient
-  params: subject={path}&_count=1000&_total=accurate
-  path: Patient.id
-  targetId: Observation
-- sourceId: Patient
-  params: subject={path}&_include=Procedure:encounter&_count=1000&_total=accurate
-  path: Patient.id
-  targetId: Procedure
-- sourceId: Patient
-  params: subject={path}&_include=MedicationAdministration:medication&_count=1000&_total=accurate
-  path: Patient.id
-  targetId: MedicationAdministration
-# No longer needed, there are no Groups with Specimen members
-#- sourceId: Specimen
-#  params: member={path}&_count=1000&_total=accurate
-#  path: Specimen.id
-#  targetId: Group
-
-# This link is a no-op, it simply links to Group to continue the traversal
-- sourceId: Specimen
+- params: part-of-study={path}&_count=1000&_total=accurate
+  sourceId: ResearchStudy
   targetId: Group
-
-- sourceId: Group
-  params: subject={path}&_count=1000&_total=accurate
-  path: Group.id
+  path: ResearchStudy.id
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: Patient
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: Specimen
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: Observation
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: Procedure
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
   targetId: DocumentReference
-
-- sourceId: Patient
-  params: subject={path}&_count=1000&_total=accurate
-  path: Patient.id
-  targetId: DocumentReference
-
-- sourceId: Specimen
-  params: subject={path}&_count=1000&_total=accurate
-  path: Specimen.id
-  targetId: DocumentReference
-
-- sourceId: Patient
-  params: source={path}&_count=1000&_total=accurate
-  path: Patient.id
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
   targetId: ServiceRequest
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: ImagingStudy
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: Condition
 
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: MedicationAdministration
 
-- sourceId: ServiceRequest
-  params: related={path}&_count=1000&_total=accurate
-  path: ServiceRequest.id
-  targetId: DocumentReference
+# R4
+- params: _id={path}&_count=1000&_total=accurate
+  path: MedicationAdministration.medicationReference.reference
+  sourceId: MedicationAdministration
+  targetId: Medication
+

--- a/graph-definitions/R5/PatientSurvivalGraph.yaml
+++ b/graph-definitions/R5/PatientSurvivalGraph.yaml
@@ -1,0 +1,14 @@
+description: A graph to traverse Patient and Observations [NCIT_C156418,NCIT_C156419].
+id: patient-survival-graph
+name: PatientSurvivalGraph
+resourceType: GraphDefinition
+status: active
+link:
+- params: part-of-study={path}&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: Patient
+- params: part-of-study={path}&code=NCIT_C156418,NCIT_C156419&_count=1000&_total=accurate
+  path: ResearchStudy.id
+  sourceId: ResearchStudy
+  targetId: Observation

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def parse_requirements(filename: str) -> list[str]:
 
 setup(
     name="fhir_query",
-    version="0.1.0",
+    version="0.1.1",
     packages=find_packages(),
     install_requires=parse_requirements("requirements.txt"),
     extras_require={

--- a/tests/unit/test_mock_server.py
+++ b/tests/unit/test_mock_server.py
@@ -48,7 +48,7 @@ def test_runner(tmp_path: str) -> None:
     print(result.stderr)
     print(result.stdout)
     assert result.exit_code == 0, "CLI command failed"
-    assert "Running research-study-graph traversal" in result.stderr
+    assert "research-study-graph" in result.stderr, result.stderr
     assert "database available at:" in result.stderr
 
     assert pathlib.Path(f"{tmp_path}/fhir-query.sqlite").exists()

--- a/tests/unit/test_parallelizer.py
+++ b/tests/unit/test_parallelizer.py
@@ -1,0 +1,21 @@
+from collections import defaultdict
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def graph_definition():
+    file_path = "tests/fixtures/ResearchStudyGraph.yaml"
+
+    # Read the YAML file
+    with open(file_path, "r") as file:
+        return yaml.safe_load(file)
+
+
+def test_parallelizer(graph_definition):
+    parallelize = defaultdict(list)
+    for link in graph_definition["link"]:
+        parallelize[link["sourceId"]].append(link)
+    expected_values = [("ResearchStudy", 2), ("Patient", 8), ("MedicationAdministration", 1), ("Specimen", 1), ("Group", 1)]
+    assert all([(k, len(v)) in expected_values for k, v in parallelize.items()])


### PR DESCRIPTION
This PR:
* improves thread processing (all requests based on a source resourceType will run in parallel)
* adds example PatientSurvivalGraph GraphDefinition

Test:
```
rm /tmp/fhir-graph.sqlite 

$ time fq  --fhir-base-url $FHIR_BASE  --graph-definition-file-path  graph-definitions/R4/PatientSurvivalGraph.yaml  --path '/ResearchStudy?identifier=TCGA-BRCA'  
patient-survival-graph is valid FHIR R5 GraphDefinition
ℹ Fetching https://google-fhir.test-fhir-aggregator.org/ResearchStudy?identifier=TCGA-BRCA
ℹ Processing ResearchStudy with 1 resources
ℹ Processing 2 links for ResearchStudy in parallel.
ℹ Processing link: Patient/part-of-study={path}&_count=1000&_total=accurate with 1 ResearchStudy(s)
ℹ Processing link: Observation/part-of-study={path}&code=NCIT_C156418,NCIT_C156419&_count=1000&_total=accurate with 1 ResearchStudy(s)
✔ Processed link: Patient/part-of-study={path}&_count=1000&_total=accurate
✔ Processed link: Observation/part-of-study={path}&code=NCIT_C156418,NCIT_C156419&_count=1000&_total=accurate
Aggregated Results: {'Observation': 1231, 'Patient': 1098, 'ResearchStudy': 1}
database available at: /tmp/fhir-graph.sqlite

real    0m4.245s
user    0m1.238s
sys     0m2.277s


fq dataframe Patient --dtale

```

![image](https://github.com/user-attachments/assets/b0b27091-ef10-4ae3-addb-3549a8d2d1c4)
