### PR TITLE
feat: Add initial PyPi release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,16 @@
 name: CI
 
-# Runs on every push / pull_request, and is also callable as a reusable workflow
+# Runs on branch pushes / pull_requests, and is also callable as a reusable workflow
 # (workflow_call) so publish.yml can reuse these checks as a release gate.
-on: [push, pull_request, workflow_call]
+#
+# Tags are excluded from the push trigger: a tag push already runs these checks via
+# publish.yml's gate, so without this exclusion CI would also fire and run them twice.
+on:
+  push:
+    tags-ignore:
+      - '**'
+  pull_request:
+  workflow_call:
 
 jobs:
   checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,19 @@
 name: CI
 
-on: [push, pull_request]
+# Runs on every push / pull_request, and is also callable as a reusable workflow
+# (workflow_call) so publish.yml can reuse these checks as a release gate.
+on: [push, pull_request, workflow_call]
 
 jobs:
-  build:
+  checks:
+    name: Run checks
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -18,14 +21,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel black mypy==1.17.0 pytest==8.4.1 pytest-cov==6.0.0 pytest-httpx==0.35.0
-
           pip install .
 
       - name: Run Black
         run: black --check --verbose fhir_aggregator_client/ tests/
 
       - name: Run Mypy
-        run: mypy --ignore-missing-imports  fhir_aggregator_client/ tests/
+        run: mypy --ignore-missing-imports fhir_aggregator_client/ tests/
 
       - name: Run Pytest
         run: pytest tests/unit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,70 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify tag matches setup.py version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          setup_version="$(python setup.py --version)"
+          echo "Tag version:      $tag_version"
+          echo "setup.py version: $setup_version"
+          if [ "$tag_version" != "$setup_version" ]; then
+            echo "::error::Tag v$tag_version does not match setup.py version $setup_version"
+            exit 1
+          fi
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/fhir-aggregator-client/
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  release:
-    types: [published]
 
 jobs:
   build:
@@ -14,23 +12,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the version from git tags, so it needs the
+          # full history (and the tag) rather than a shallow clone.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Verify tag matches setup.py version
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          tag_version="${GITHUB_REF_NAME#v}"
-          setup_version="$(python setup.py --version)"
-          echo "Tag version:      $tag_version"
-          echo "setup.py version: $setup_version"
-          if [ "$tag_version" != "$setup_version" ]; then
-            echo "::error::Tag v$tag_version does not match setup.py version $setup_version"
-            exit 1
-          fi
 
       - name: Install build tooling
         run: python -m pip install --upgrade pip build
@@ -68,3 +58,33 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required to create a GitHub Release
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # Mark PEP 440 pre-releases (rc/a/b/dev) as GitHub pre-releases.
+          prerelease_flag=""
+          if [[ "${GITHUB_REF_NAME}" =~ (rc|a|b|alpha|beta|dev) ]]; then
+            prerelease_flag="--prerelease"
+          fi
+          gh release create "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            ${prerelease_flag} \
+            dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,12 @@ on:
       - 'v*'
 
 jobs:
+  checks:
+    uses: ./.github/workflows/ci.yml
+
   build:
     name: Build distribution
+    needs: checks
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,24 +100,43 @@ Thank you for contributing to our project! Your efforts are highly appreciated. 
 
 Releases to [PyPI](https://pypi.org/project/fhir-aggregator-client/) are published
 automatically by the [`Publish to PyPI`](.github/workflows/publish.yml) GitHub Action
-whenever a `v*` tag is pushed. The action builds the sdist and wheel and uploads them
-using [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), so
-no API tokens or passwords need to be stored or exported.
+whenever a `v*` tag is pushed. The action builds the sdist and wheel, uploads them
+using [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — so
+no API tokens or passwords need to be stored or exported — and creates a matching
+[GitHub Release](https://github.com/FHIR-Aggregator/fhir-aggregator-client/releases)
+with the built artifacts attached.
+
+The package version is derived from the git tag by
+[`setuptools-scm`](https://setuptools-scm.readthedocs.io/) (configured in
+[`pyproject.toml`](pyproject.toml)). There is **no version string to edit** — the tag
+is the single source of truth, and `fq --version` reports whatever was tagged.
 
 ### Cutting a release
 
-1. Bump the `version` in [`setup.py`](setup.py) (e.g. `0.2.2` -> `0.2.3`).
-2. Commit the bump and merge it to the default branch.
-3. Tag the commit and push the tag:
+```
+git checkout development && git pull
+git tag v0.2.4
+git push origin v0.2.4
+```
 
-   ```
-   git tag v0.2.3
-   git push origin v0.2.3
-   ```
+That's it: the tag triggers the build, the PyPI upload, and the GitHub Release.
 
-The tag version (without the leading `v`) must match the `version` in `setup.py`;
-the workflow verifies this and fails the build if they disagree, before anything is
-published.
+### Pre-releases
+
+Use a [PEP 440](https://peps.python.org/pep-0440/) pre-release tag (`rc`, `a`, or `b`):
+
+```
+git tag v0.3.0rc1
+git push origin v0.3.0rc1
+```
+
+The workflow marks it as a pre-release on GitHub, and PyPI marks it as a pre-release
+automatically: a plain `pip install fhir-aggregator-client` skips it, and users opt in
+with
+
+```
+pip install --pre fhir-aggregator-client   # or pin: ==0.3.0rc1
+```
 
 ### Building locally (optional)
 
@@ -125,7 +144,39 @@ To produce the distribution artifacts on your machine without publishing:
 
 ```
 rm -rf build/ dist/
-python3 -m build
+python -m build
 twine check dist/*
 ```
+
+### Manual release (fallback)
+
+The tag-triggered workflow above is the normal path, but a maintainer can still
+publish by hand (e.g. if CI is unavailable). Token-based `twine` uploads continue to
+work alongside Trusted Publishing.
+
+> **Important:** the version is derived from git by `setuptools-scm`, so **build from
+> the tag**, not from a branch. Building from an untagged commit produces a development
+> version like `0.2.4.post3` instead of the clean `0.2.4` you intend.
+
+```sh
+# 1. Create and push the tag (or check out an existing one)
+git checkout development && git pull
+git tag v0.2.4
+git push origin v0.2.4
+
+# 2. Build FROM the tag so setuptools-scm resolves a clean version
+git checkout v0.2.4
+rm -rf build/ dist/
+python -m build
+twine check dist/*
+
+# 3. Upload (uses your PyPI API token; see
+#    https://twine.readthedocs.io/en/stable/#environment-variables)
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD=pypi-...
+twine upload dist/*
+```
+
+Avoid publishing the same version both manually and via the workflow — PyPI rejects
+duplicate uploads of an existing version.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,21 +98,34 @@ Thank you for contributing to our project! Your efforts are highly appreciated. 
 
 ## Distribution
 
-- PyPi
+Releases to [PyPI](https://pypi.org/project/fhir-aggregator-client/) are published
+automatically by the [`Publish to PyPI`](.github/workflows/publish.yml) GitHub Action
+whenever a `v*` tag is pushed. The action builds the sdist and wheel and uploads them
+using [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), so
+no API tokens or passwords need to be stored or exported.
+
+### Cutting a release
+
+1. Bump the `version` in [`setup.py`](setup.py) (e.g. `0.2.2` -> `0.2.3`).
+2. Commit the bump and merge it to the default branch.
+3. Tag the commit and push the tag:
+
+   ```
+   git tag v0.2.3
+   git push origin v0.2.3
+   ```
+
+The tag version (without the leading `v`) must match the `version` in `setup.py`;
+the workflow verifies this and fails the build if they disagree, before anything is
+published.
+
+### Building locally (optional)
+
+To produce the distribution artifacts on your machine without publishing:
 
 ```
-# update pypi
-
-# pypi credentials - see https://twine.readthedocs.io/en/stable/#environment-variables
-
-export TWINE_USERNAME=  #  the username to use for authentication to the repository.
-export TWINE_PASSWORD=  # the password to use for authentication to the repository.
-
-# this could be maintained as so: export $(cat .env | xargs)
-
-rm -r build/
-rm -r dist/
-python3  setup.py sdist bdist_wheel
-twine upload dist/*
-
+rm -rf build/ dist/
+python3 -m build
+twine check dist/*
 ```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,11 @@ python_version = 3.12
 strict = true
 
 [build-system]
-requires = ["setuptools", "wheel", "black", "mypy", "pytest", "pytest-cov", "pytest_httpx"]
+requires = ["setuptools>=64", "setuptools-scm>=8", "wheel", "black", "mypy", "pytest", "pytest-cov", "pytest_httpx"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# Version is derived from the latest git tag (e.g. v0.2.4 -> 0.2.4).
+# Writes the resolved version into the build so importlib.metadata can read it.
+version_scheme = "post-release"
+local_scheme = "no-local-version"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name="fhir_aggregator_client",
-    version="0.2.3",
+    # version is derived from git tags by setuptools-scm (see pyproject.toml)
     packages=find_packages(exclude=['ez_setup', 'tests', 'tests.*']),
     install_requires=parse_requirements("requirements.txt"),
     long_description=long_description,


### PR DESCRIPTION
# Overview 🌀

This PR adds automated PyPI publishing via a GitHub Action ([`publish.yml`](.github/workflows/publish.yml))!

## Current Behavior ⚠️

Releases are only created manually ([`CONTRIBUTING.md`](https://github.com/FHIR-Aggregator/fhir-aggregator-client/blob/v0.2.0/CONTRIBUTING.md#distribution)), with PyPI credentials exported into the shell:

```sh
➜ export TWINE_USERNAME=... TWINE_PASSWORD=...

➜ rm -r build/

➜ rm -r dist/

➜ python3  setup.py sdist bdist_wheel

➜ twine upload dist/*
```

## New Behavior ✔️

Releases can still be created manually with the steps above (backwards compatible):

```sh
# Build from the latest tag (e.g. v0.3.0) so setuptools-scm resolves a clean version
➜ git checkout v0.3.0

➜ rm -rf build/ dist/

➜ python -m build

➜ twine check dist/*
```

Releases can now also be created automatically when a v* tag is pushed (via [`setuptools-scm`](https://setuptools-scm.readthedocs.io/)):

> [!IMPORTANT]
>
> There is no version string to bump, the git tag is the source of truth!

```sh
➜ git checkout development

➜ git pull

➜ git tag v0.3.1

➜ git push origin v0.3.1
```

The workflow then:

- Builds + validates the package
- Publishes to PyPI via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
- Creates a matching [GitHub Release](https://github.com/FHIR-Aggregator/fhir-aggregator-client/releases)

## Breaking Changes? ❌

- [x] No — this adds automatic PyPI publishing while keeping the manual release process available.
